### PR TITLE
sr_tactile_sensor_controller to publish tactile data

### DIFF
--- a/sr_ros_controllers/sr_tactile_sensor_controller/CMakeLists.txt
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(sr_tactile_sensor_controller)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  controller_interface
+  pluginlib
+  realtime_tools
+  ros_ethercat_model
+  roscpp
+  sr_robot_lib
+  sr_robot_msgs
+  sr_hardware_interface
+)
+
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} 
+src/sr_ubi_tactile_sensor_controller.cpp src/sr_tactile_sensor_controller.cpp)
+add_dependencies(sr_tactile_sensor_controller ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+# Declare catkin package
+catkin_package(
+CATKIN_DEPENDS controller_interface sr_hardware_interface pluginlib sr_robot_msgs realtime_tools ros_ethercat_model sr_robot_lib
+INCLUDE_DIRS include
+LIBRARIES ${PROJECT_NAME}
+)

--- a/sr_ros_controllers/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_tactile_sensor_controller.hpp
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_tactile_sensor_controller.hpp
@@ -1,0 +1,76 @@
+ /**
+ * @file   sr_tactile_sensor_controller.hpp
+ * @author Guillaume Walck <gwalck@techfak.uni-bielefeld.de>
+ * @date   Aug 22 2014
+ *
+ *
+ * @brief  Generic controller for tactile sensor data publishing.
+ *
+ */
+ 
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2012, hiDOF INC.
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+
+#ifndef SR_TACTILE_SENSOR_CONTROLLER_H
+#define SR_TACTILE_SENSOR_CONTROLLER_H
+
+#include <controller_interface/controller.h>
+#include <sr_robot_lib/generic_tactiles.hpp>
+#include <sr_hardware_interface/sr_actuator.hpp>
+#include <boost/shared_ptr.hpp>
+#include <ros_ethercat_model/robot_state.hpp>
+
+namespace controller
+{
+  // this controller gets access to the SrTactileSensorInterface
+  class SrTactileSensorController: public controller_interface::Controller<ros_ethercat_model::RobotState>
+  {
+  public:
+    SrTactileSensorController(){}
+
+    virtual bool init(ros_ethercat_model::RobotState* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh);
+    virtual void starting(const ros::Time& time);
+    virtual void update(const ros::Time& time, const ros::Duration& period);
+    virtual void stopping(const ros::Time& time);
+
+  protected:
+    std::vector<tactiles::AllTactileData>* sensors_;
+    ros::Time last_publish_time_;
+    double publish_rate_;
+  };
+
+}// namespace
+
+/* For the emacs weenies in the crowd.
+Local Variables:
+   c-basic-offset: 2
+End:
+*/
+
+#endif /* SR_TACTILE_SENSOR_CONTROLLER_H */

--- a/sr_ros_controllers/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_ubi_tactile_sensor_controller.hpp
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_ubi_tactile_sensor_controller.hpp
@@ -1,0 +1,77 @@
+/**
+ * @file   sr_ubi_tactile_sensor_controller.hpp
+ * @author Guillaume Walck <gwalck@techfak.uni-bielefeld.de>
+ * @date   Aug 25 2014
+ *
+ *
+ * @brief  Publishes ubi tactile state
+ *
+ */
+ 
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2012, hiDOF INC.
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+
+#ifndef SR_UBI_TACTILE_SENSOR_CONTROLLER_H
+#define SR_UBI_TACTILE_SENSOR_CONTROLLER_H
+
+#include <sr_tactile_sensor_controller/sr_tactile_sensor_controller.hpp>
+#include <realtime_tools/realtime_publisher.h>
+#include <sr_robot_msgs/UBI0All.h>
+#include <sr_robot_msgs/MidProxDataAll.h>
+#include <pluginlib/class_list_macros.h>
+
+namespace controller
+{
+
+  class SrUbiTactileSensorController: public SrTactileSensorController
+  {
+  public:
+    SrUbiTactileSensorController() : SrTactileSensorController() {}
+    virtual bool init(ros_ethercat_model::RobotState* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh);
+    virtual void update(const ros::Time& time, const ros::Duration& period);
+
+  private:
+   
+    typedef boost::shared_ptr<realtime_tools::RealtimePublisher<sr_robot_msgs::UBI0All> > UbiPublisherPtr;
+    typedef boost::shared_ptr<realtime_tools::RealtimePublisher<sr_robot_msgs::MidProxDataAll> > MidProxPublisherPtr;
+    UbiPublisherPtr ubi_realtime_pub_;
+    MidProxPublisherPtr midprox_realtime_pub_;
+
+  };
+
+}// namespace
+
+/* For the emacs weenies in the crowd.
+Local Variables:
+   c-basic-offset: 2
+End:
+*/
+
+#endif /* SR_UBI_TACTILE_SENSOR_CONTROLLER_H */

--- a/sr_ros_controllers/sr_tactile_sensor_controller/package.xml
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/package.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<package>
+  <name>sr_tactile_sensor_controller</name>
+  <version>0.0.1</version>
+  <description>The sr_tactile_sensor_controller package</description>
+
+  <maintainer email="gwalck@techfak.uni-bielefeld.de">Guillaume Walck</maintainer>
+  <license>BSD</license>
+
+  <url type="website">http://wiki.ros.org/sr_ros_controllers</url>
+
+  <author email="gwalck@techfak.uni-bielefeld.de">Guillaume Walck</author>
+  
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>controller_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>realtime_tools</build_depend>
+  <build_depend>ros_ethercat_model</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sr_robot_lib</build_depend>
+  <build_depend>sr_robot_msgs</build_depend>
+  <build_depend>sr_hardware_interface</build_depend>
+  
+  <run_depend>controller_interface</run_depend>
+  <run_depend>pluginlib</run_depend>
+  <run_depend>realtime_tools</run_depend>
+  <run_depend>ros_ethercat_model</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sr_robot_lib</run_depend>
+  <run_depend>sr_robot_msgs</run_depend>
+  <run_depend>sr_hardware_interface</run_depend>
+
+
+  <export>
+    <controller_interface plugin="${prefix}/sr_tactile_sensor_plugin.xml"/>
+  </export>
+</package>

--- a/sr_ros_controllers/sr_tactile_sensor_controller/sr_tactile_sensor.launch
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/sr_tactile_sensor.launch
@@ -1,0 +1,9 @@
+<launch>
+  <group ns="rh">
+  <!-- load configuration -->
+  <rosparam command="load" file="$(find sr_tactile_sensor_controller)/sr_ubi_tactile_sensor_controller.yaml" />
+
+  <!-- spawn controller -->
+  <node name="sr_tactile_sensor_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="sr_ubi_tactile_sensor_controller" />
+  </group>
+</launch>

--- a/sr_ros_controllers/sr_tactile_sensor_controller/sr_tactile_sensor_plugin.xml
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/sr_tactile_sensor_plugin.xml
@@ -1,0 +1,7 @@
+<library path="lib/libsr_tactile_sensor_controller">
+  <class name="sr_tactile_sensor_controller/SrUbiTactileSensorController" type="controller::SrUbiTactileSensorController" base_class_type="controller_interface::ControllerBase">
+    <description>
+    This controller publishes the readings of all available tactile sensors as sr_robot_msgs/UBI0All and sr_robot_msgs/MidProxDataAll messages. The controller expects a RobotState type of hardware interface.
+    </description>
+  </class>
+</library>

--- a/sr_ros_controllers/sr_tactile_sensor_controller/sr_ubi_tactile_sensor_controller.yaml
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/sr_ubi_tactile_sensor_controller.yaml
@@ -1,0 +1,3 @@
+sr_ubi_tactile_sensor_controller:
+  type: sr_tactile_sensor_controller/SrUbiTactileSensorController
+  publish_rate: 100

--- a/sr_ros_controllers/sr_tactile_sensor_controller/src/sr_tactile_sensor_controller.cpp
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/src/sr_tactile_sensor_controller.cpp
@@ -1,0 +1,85 @@
+/**
+ * @file   sr_tactile_sensor_controller.cpp
+ * @author Guillaume Walck <gwalck@techfak.uni-bielefeld.de>
+ * @date   Aug 22 2014
+ *
+ *
+ * @brief  Generic controller for tactile sensor data publishing.
+ *
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2012, hiDOF INC.
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of PAL Robotics S.L. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+
+#include "sr_tactile_sensor_controller/sr_tactile_sensor_controller.hpp"
+
+using namespace std;
+
+namespace controller
+{
+  bool SrTactileSensorController::init(ros_ethercat_model::RobotState* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh)
+  {
+    // get all sensors from the hardware interface
+    // apparently all the actuators have the tactile data copied in, so take the first one.
+    sr_actuator::SrMotorActuator* motor_actuator = static_cast<sr_actuator::SrMotorActuator*> (hw->getActuator("FFJ0"));
+    sensors_ = motor_actuator->motor_state_.tactiles_;
+
+    // get publishing period
+    if (!controller_nh.getParam("publish_rate", publish_rate_)){
+      ROS_ERROR("Parameter 'publish_rate' not set");
+      return false;
+    }
+       
+    return true;
+  }
+  
+  void SrTactileSensorController::update(const ros::Time& time, const ros::Duration& period)
+  {
+  }
+
+  void SrTactileSensorController::starting(const ros::Time& time)
+  {
+    // initialize time
+    last_publish_time_ = time;
+  }
+  
+   void SrTactileSensorController::stopping(const ros::Time& time)
+  {}
+}
+
+
+
+
+/* For the emacs weenies in the crowd.
+Local Variables:
+   c-basic-offset: 2
+End:
+ */
+
+

--- a/sr_ros_controllers/sr_tactile_sensor_controller/src/sr_ubi_tactile_sensor_controller.cpp
+++ b/sr_ros_controllers/sr_tactile_sensor_controller/src/sr_ubi_tactile_sensor_controller.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file   sr_ubi_tactile_sensor_controller.cpp
+ * @author Guillaume Walck <gwalck@techfak.uni-bielefeld.de>
+ * @date   Aug 25 2014
+ *
+ *
+ * @brief  Publishes ubi tactile state.
+ *
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2012, hiDOF INC.
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of PAL Robotics S.L. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+
+#include "sr_tactile_sensor_controller/sr_ubi_tactile_sensor_controller.hpp"
+
+using namespace std;
+
+namespace controller
+{
+  bool SrUbiTactileSensorController::init(ros_ethercat_model::RobotState* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh) 
+  {
+    bool ret=SrTactileSensorController::init(hw, root_nh, controller_nh);
+    if (ret)
+    {
+      // realtime publisher
+      ubi_realtime_pub_ = UbiPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::UBI0All>(root_nh, "ubi_tactile", 4));
+      midprox_realtime_pub_ = MidProxPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::MidProxDataAll>(root_nh, "mid_prox_tactile", 4));
+    }
+    return ret;
+  }
+
+  void SrUbiTactileSensorController::update(const ros::Time& time, const ros::Duration& period)
+  {
+    using namespace hardware_interface;
+    bool ubi_published=false;
+    // limit rate of publishing
+    if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0/publish_rate_) < time){
+      // try to publish
+      if (ubi_realtime_pub_->trylock()){
+        // we're actually publishing, so increment time
+        last_publish_time_ = last_publish_time_ + ros::Duration(1.0/publish_rate_);
+        ubi_published=true;
+        // populate message
+        ubi_realtime_pub_->msg_.header.stamp = time;
+        ubi_realtime_pub_->msg_.header.frame_id = "palm";
+        // data
+        for (unsigned i=0; i<sensors_->size(); i++){
+          sr_robot_msgs::UBI0 tactile_tmp;
+         
+          tactile_tmp.distal = sensors_->at(i).ubi0.distal;
+          ubi_realtime_pub_->msg_.tactiles[i] = tactile_tmp;
+        }
+        ubi_realtime_pub_->unlockAndPublish();
+        
+      }     
+      
+       // try to publish
+      if (midprox_realtime_pub_->trylock()){
+        // we're actually publishing, so increment time
+        if( !ubi_published)
+          last_publish_time_ = last_publish_time_ + ros::Duration(1.0/publish_rate_);
+        // populate message
+        midprox_realtime_pub_->msg_.header.stamp = time;
+        midprox_realtime_pub_->msg_.header.frame_id = "palm";
+        // data
+        for (unsigned i=0; i<sensors_->size(); i++){
+          sr_robot_msgs::MidProxData midprox_tmp;
+          
+          midprox_tmp.middle = sensors_->at(i).ubi0.middle;
+          midprox_tmp.proximal = sensors_->at(i).ubi0.proximal;
+          midprox_realtime_pub_->msg_.sensors[i] = midprox_tmp;
+        }
+        midprox_realtime_pub_->unlockAndPublish();       
+      }   
+    }
+  }
+}
+
+
+PLUGINLIB_EXPORT_CLASS(controller::SrUbiTactileSensorController, controller_interface::ControllerBase)
+
+/* For the emacs weenies in the crowd.
+Local Variables:
+   c-basic-offset: 2
+End:
+ */
+
+


### PR DESCRIPTION
ros_control suggests to publish data coming from a robot driver through interfaces and controllers

this controller publishes the tactile data of type UBI, accessing the robotstate registered interface. This way one can easily change the publishing frequency without perturbing the main control loop. Data pre-processing could also be put in such controllers before publishing.

Only UBI tactile sensor publisher is implemented currently, but it makes use of a generic controller that has the handler to the 3 supported tactile sensor types.

No driver modification is required.
Tested on a right hand with UBI sensors at speed up to 1kHz (maximum since main loop is at this speed)
