### PR TITLE
Support for bimanual setups

### DIFF
--- a/sr_edc_launch/sr_edc_bimanual.launch
+++ b/sr_edc_launch/sr_edc_bimanual.launch
@@ -98,4 +98,16 @@
   <node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="100.0" />
   </node>
+  
+    <!-- adding tactile state publisher using the tf prefix as a namespace -->
+  <include file="$(find sr_tactile_sensor_controller)/sr_tactile_sensor.launch">
+   <arg name="prefix" value="$(arg rh_id)_" />
+   <arg name="config_dir" value="$(arg rh_id)/" />
+  </include>
+  
+  <include file="$(find sr_tactile_sensor_controller)/sr_tactile_sensor.launch">
+   <arg name="prefix" value="$(arg lh_id)_" />
+   <arg name="config_dir" value="$(arg lh_id)/" />
+  </include>  
+  
 </launch>

--- a/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_biotac_tactile_sensor_controller.hpp
+++ b/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_biotac_tactile_sensor_controller.hpp
@@ -6,7 +6,7 @@
  *
  */
 
-/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+/// derived from ImuSensorController  author: Adolfo Rodriguez Tsouroukdissian
 
 #pragma once
 

--- a/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_pst_tactile_sensor_controller.hpp
+++ b/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_pst_tactile_sensor_controller.hpp
@@ -6,7 +6,7 @@
  *
  */
 
-/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+/// derived from ImuSensorController  author: Adolfo Rodriguez Tsouroukdissian
 
 #pragma once
 

--- a/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_tactile_sensor_controller.hpp
+++ b/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_tactile_sensor_controller.hpp
@@ -35,7 +35,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
-/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+/// derived from ImuSensorController  author: Adolfo Rodriguez Tsouroukdissian
 
 #ifndef SR_TACTILE_SENSOR_CONTROLLER_H
 #define SR_TACTILE_SENSOR_CONTROLLER_H
@@ -63,6 +63,8 @@ namespace controller
     std::vector<tactiles::AllTactileData>* sensors_;
     ros::Time last_publish_time_;
     double publish_rate_;
+    ros::NodeHandle nh_prefix_;
+    std::string prefix_;
   };
 
 }// namespace

--- a/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_ubi_tactile_sensor_controller.hpp
+++ b/sr_tactile_sensor_controller/include/sr_tactile_sensor_controller/sr_ubi_tactile_sensor_controller.hpp
@@ -35,8 +35,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
-
-/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+/// derived from ImuSensorController  author: Adolfo Rodriguez Tsouroukdissian
 
 #ifndef SR_UBI_TACTILE_SENSOR_CONTROLLER_H
 #define SR_UBI_TACTILE_SENSOR_CONTROLLER_H

--- a/sr_tactile_sensor_controller/sr_tactile_sensor.launch
+++ b/sr_tactile_sensor_controller/sr_tactile_sensor.launch
@@ -1,25 +1,29 @@
 <launch>
+  <!-- prefix for the spawner node and the controller (might be different from joint_name prefix) -->
+  <arg name="prefix" default=""/>
+  <!-- config_dir to access the correct set of tactile sensors parameters (which contain the joint_name prefix) -->
+  <arg name="config_dir" default="" />
   <!-- load configuration -->
   <group if="$(optenv BIOTAC_HAND 0)">
-      <rosparam command="load" file="$(find sr_ethercat_hand_config)/controls/tactiles/sr_biotac_tactile_sensor_controller.yaml" />
+      <rosparam command="load" file="$(find sr_ethercat_hand_config)/controls/tactiles/$(arg config_dir)sr_biotac_tactile_sensor_controller.yaml" />
 
       <!-- spawn controller -->
-      <node name="sr_tactile_sensor_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="--shutdown-timeout=1 sr_biotac_tactile_sensor_controller" />
+      <node name="sr_$(arg prefix)tactile_sensor_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="--shutdown-timeout=1 sr_$(arg prefix)biotac_tactile_sensor_controller" />
   </group> <!-- BIOTACS -->
 
   <group unless="$(optenv BIOTAC_HAND 0)">
     <group if="$(optenv UBI_HAND 0)">
-      <rosparam command="load" file="$(find sr_ethercat_hand_config)/controls/tactiles/sr_ubi_tactile_sensor_controller.yaml" />
+      <rosparam command="load" file="$(find sr_ethercat_hand_config)/controls/tactiles/$(arg config_dir)sr_ubi_tactile_sensor_controller.yaml" />
 
       <!-- spawn controller -->
-      <node name="sr_tactile_sensor_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="--shutdown-timeout=1 sr_ubi_tactile_sensor_controller" />
+      <node name="sr_$(arg prefix)tactile_sensor_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="--shutdown-timeout=1 sr_$(arg prefix)ubi_tactile_sensor_controller" />
     </group> <!-- UBI -->
 
     <group unless="$(optenv UBI_HAND 0)">
-      <rosparam command="load" file="$(find sr_ethercat_hand_config)/controls/tactiles/sr_pst_tactile_sensor_controller.yaml" />
+      <rosparam command="load" file="$(find sr_ethercat_hand_config)/controls/tactiles/$(arg config_dir)sr_pst_tactile_sensor_controller.yaml" />
 
       <!-- spawn controller -->
-      <node name="sr_tactile_sensor_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="--shutdown-timeout=1 sr_pst_tactile_sensor_controller" />
+      <node name="sr_$(arg prefix)tactile_sensor_controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="--shutdown-timeout=1 sr_$(arg prefix)pst_tactile_sensor_controller" />
     </group> <!-- PSTS -->
   </group>
 </launch>

--- a/sr_tactile_sensor_controller/src/sr_biotac_tactile_sensor_controller.cpp
+++ b/sr_tactile_sensor_controller/src/sr_biotac_tactile_sensor_controller.cpp
@@ -21,7 +21,7 @@ namespace controller
     if (ret)
     {
       // realtime publisher
-      biotac_realtime_pub_ = BiotacPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::BiotacAll>(root_nh, "tactile", 4));
+      biotac_realtime_pub_ = BiotacPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::BiotacAll>(nh_prefix_, "tactile", 4));
     }
     return ret;
   }
@@ -41,7 +41,7 @@ namespace controller
         biotac_published=true;
         // populate message
         biotac_realtime_pub_->msg_.header.stamp = time;
-        biotac_realtime_pub_->msg_.header.frame_id = "palm";
+        biotac_realtime_pub_->msg_.header.frame_id = prefix_+"distal";
         // data
 	for (unsigned i=0; i<sensors_->size(); i++)
 	{

--- a/sr_tactile_sensor_controller/src/sr_pst_tactile_sensor_controller.cpp
+++ b/sr_tactile_sensor_controller/src/sr_pst_tactile_sensor_controller.cpp
@@ -21,7 +21,7 @@ namespace controller
     if (ret)
     {
       // realtime publisher
-      pst_realtime_pub_ = PSTPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::ShadowPST>(root_nh, "tactile", 4));
+      pst_realtime_pub_ = PSTPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::ShadowPST>(nh_prefix_, "tactile", 4));
     }
     return ret;
   }
@@ -41,7 +41,7 @@ namespace controller
         pst_published=true;
         // populate message
         pst_realtime_pub_->msg_.header.stamp = time;
-        pst_realtime_pub_->msg_.header.frame_id = "palm";
+        pst_realtime_pub_->msg_.header.frame_id = prefix_+"distal";
         // data
 	for (unsigned i=0; i<sensors_->size(); i++)
 	{

--- a/sr_tactile_sensor_controller/src/sr_tactile_sensor_controller.cpp
+++ b/sr_tactile_sensor_controller/src/sr_tactile_sensor_controller.cpp
@@ -35,7 +35,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
-/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+/// derived from ImuSensorController  author: Adolfo Rodriguez Tsouroukdissian
 
 #include "sr_tactile_sensor_controller/sr_tactile_sensor_controller.hpp"
 
@@ -45,14 +45,26 @@ namespace controller
 {
   bool SrTactileSensorController::init(ros_ethercat_model::RobotState* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh)
   {
+    
+    if (!controller_nh.getParam("prefix", prefix_)){
+      ROS_ERROR("Parameter 'prefix' not set");
+      return false;
+    }
+    
+    //this should handle the case where we don't want a prefix
+    if (!prefix_.empty())
+    {
+      nh_prefix_ = ros::NodeHandle(root_nh, prefix_);
+      prefix_+="_";
+    }
+    else
+    {
+      nh_prefix_ = ros::NodeHandle(root_nh);
+    }
+    
     // get all sensors from the hardware interface
     // apparently all the actuators have the tactile data copied in, so take the first one.
-    sr_actuator::SrMotorActuator* motor_actuator=NULL;
-    if (hw->transmissions_.size()>0)
-    {
-      motor_actuator = static_cast<sr_actuator::SrMotorActuator*>  (hw->transmissions_[0].actuator_);
-    }
-    //sr_actuator::SrMotorActuator* motor_actuator = static_cast<sr_actuator::SrMotorActuator*> (hw->getActuator("FFJ0"));
+    sr_actuator::SrMotorActuator* motor_actuator = static_cast<sr_actuator::SrMotorActuator*> (hw->getActuator(prefix_+"FFJ0"));
     if (motor_actuator)
     {
       sensors_ = motor_actuator->motor_state_.tactiles_;
@@ -67,7 +79,7 @@ namespace controller
     }
     else
     {
-      ROS_ERROR("Could not find at least an actuator with tactile data inside");
+      ROS_ERROR_STREAM("Could not find the "<<prefix_<<"FFJ0 actuator");
       return false;
     }
   }

--- a/sr_tactile_sensor_controller/src/sr_ubi_tactile_sensor_controller.cpp
+++ b/sr_tactile_sensor_controller/src/sr_ubi_tactile_sensor_controller.cpp
@@ -35,7 +35,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
-/// Original author of ImuSensorController : Adolfo Rodriguez Tsouroukdissian
+/// derived from ImuSensorController  author: Adolfo Rodriguez Tsouroukdissian
 
 #include "sr_tactile_sensor_controller/sr_ubi_tactile_sensor_controller.hpp"
 #include <pluginlib/class_list_macros.h>
@@ -50,8 +50,8 @@ namespace controller
     if (ret)
     {
       // realtime publisher
-      ubi_realtime_pub_ = UbiPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::UBI0All>(root_nh, "tactile", 4));
-      midprox_realtime_pub_ = MidProxPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::MidProxDataAll>(root_nh, "tactile_mid_prox", 4));
+      ubi_realtime_pub_ = UbiPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::UBI0All>(nh_prefix_, "tactile", 4));
+      midprox_realtime_pub_ = MidProxPublisherPtr(new realtime_tools::RealtimePublisher<sr_robot_msgs::MidProxDataAll>(nh_prefix_, "tactile_mid_prox", 4));
     }
     return ret;
   }
@@ -70,7 +70,7 @@ namespace controller
         ubi_published=true;
         // populate message
         ubi_realtime_pub_->msg_.header.stamp = time;
-        ubi_realtime_pub_->msg_.header.frame_id = "palm";
+        ubi_realtime_pub_->msg_.header.frame_id = prefix_+"distal";
         // data
         for (unsigned i=0; i<sensors_->size(); i++){
           sr_robot_msgs::UBI0 tactile_tmp;
@@ -89,7 +89,7 @@ namespace controller
           last_publish_time_ = last_publish_time_ + ros::Duration(1.0/publish_rate_);
         // populate message
         midprox_realtime_pub_->msg_.header.stamp = time;
-        midprox_realtime_pub_->msg_.header.frame_id = "palm";
+        midprox_realtime_pub_->msg_.header.frame_id = prefix_+"proximal";
         // data
         for (unsigned i=0; i<sensors_->size(); i++){
           sr_robot_msgs::MidProxData midprox_tmp;


### PR DESCRIPTION
Added support for bimanual setups is sr_tactile_sensor_controllers
also modified tactile frame to distal instead of palm

tested with 2-hand system (sr_edc_bimanual.launch) and 1 hand system (sr_edc.launch), topics correctly advertized and distinguished in two hand system in a single realtime loop.
**requires** a fix of sr_config files to add prefix parameter as in **sr_config/sr_ethercat_hand_config/controls/tactiles/sr_ubi_tactile_sensor_controller.yaml**

```
sr_ubi_tactile_sensor_controller:
  type: sr_tactile_sensor_controller/SrUbiTactileSensorController
  publish_rate: 1000
  prefix: ""
```

**requires** new files in sr_ethercat_config when using **bimanual system** . For instance **in folder sr_config/sr_ethercat_hand_config/controls/tactiles/lh/sr_ubi_tactile_sensor_controller.yaml**

```

sr_lh_ubi_tactile_sensor_controller:
  type: sr_tactile_sensor_controller/SrUbiTactileSensorController
  publish_rate: 1000
  prefix: lh
```
