### PR TITLE
adding readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This stack focuses on the drivers for our [etherCAT hand](http://www.shadowrobot.com/products/).
 
+**Warning: be careful when starting the hand. Make sure you're using the proper config files or you might damage the hardware. If in doubt contact us!**
+
 ## Launching the Hand Driver
 
 - `sr_edc.launch` Launches a single hand

--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
-# sr_edc_launch
+# Shadow Robot - EtherCAT driver
 
-This package contain launchfiles for the Shadow Robot EDC (EtherCAT Dual CAN) hand.
+This stack focuses on the drivers for our [etherCAT hand](http://www.shadowrobot.com/products/).
 
-## Contents
+## Launching the Hand Driver
 
 - `sr_edc.launch` Launches a single hand
 
 - `sr_edc_bimanual.launch` Launches 2 hands (as part of the same bimanual robot)
 
 
-## Use
+### Use
 
-### Direct use
+#### Direct use
 
 For a single hand, with default parameters:
 
-```
+```bash
 roslaunch sr_edc_launch sr_edc.launch
 ```
 
 For a bimanual system you will need to specify at least the serial numbers for the right and left hand:
 
-```
+```bash
 roslaunch sr_edc_launch sr_edc_bimanual.launch rh_serial:=1234 lh_serial:=1235
 ```
 
-### Use from another launchfile
+#### Use from another launchfile
 
 E.g. for a bimanual system:
 
-```
+```xml
 <launch>
   <include file="$(find sr_edc_launch)/sr_edc_bimanual.launch" >
     <arg name="rh_serial" value="1234" />
@@ -42,7 +42,7 @@ E.g. for a bimanual system:
 
 E.g. for a single hand system:
 
-```
+```xml
 <launch>
   <include file="$(find sr_edc_launch)/sr_edc.launch" >
     <arg name="eth_port" value="eth1" />
@@ -51,7 +51,7 @@ E.g. for a single hand system:
 </launch>
 ```
 
-### Available arguments for sr_edc_bimanual.launch
+#### Available arguments for sr_edc_bimanual.launch
 
 - `eth_port`: The ethernet port/s that will be used to search for etherCAT devices (shadow hands or other devices like RoNeX). More than one port can be provided in this argument, using underscore as a separator.
 
@@ -62,19 +62,19 @@ roslaunch sr_edc_launch sr_edc_bimanual.launch rh_serial:=1234 lh_serial:=1235 e
 - `debug`: Set to true for debugging
 - `calibration_controllers`: Set to 0 if we don't want to run calibration controllers (e.g. for the muscle hand)
 - `robot_description`: Xacro file containing the robot description we want to load
-- `pwm_control`: The control mode PWM (true) or torque (false) 
+- `pwm_control`: The control mode PWM (true) or torque (false)
 - `rh_serial`: The ethercat serial number for the right hand
 - `rh_id`: The id for the right hand. It needs to be the same (but without trailing underscore) as the prefix used in the hand model.
 - `lh_serial`: The ethercat serial number for the left hand
 - `lh_id`: The id for the left hand. It needs to be the same (but without trailing underscore) as the prefix used in the hand model.
 
-### Available arguments for sr_edc.launch
+#### Available arguments for sr_edc.launch
 
 - `eth_port`: The ethernet port/s that will be used to search for etherCAT devices (shadow hands or other devices like RoNeX). More than one port can be provided in this argument, using underscore as a separator.
 - `debug`: Set to true for debugging
 - `calibration_controllers`: Set to 0 if we don't want to run calibration controllers (e.g. for the muscle hand)
 - `robot_description`: Xacro file containing the robot description we want to load
-- `pwm_control`: The control mode PWM (true) or torque (false) 
+- `pwm_control`: The control mode PWM (true) or torque (false)
 - `config_dir`: Defines the sub-directory used in
        $(find sr_ethercat_hand_config)/mappings/
        and $(find sr_ethercat_hand_config)/calibrations/


### PR DESCRIPTION
Reorganising a bit for a cleaner documentation generation: 

built documentation is visible here:

http://shadow-robot-ethercat-driver.readthedocs.org/en/F_add_readme/
