### PR TITLE
B#111 better prefix handling

### DIFF
--- a/sr_edc_ethercat_drivers/src/sr_edc.cpp
+++ b/sr_edc_ethercat_drivers/src/sr_edc.cpp
@@ -187,9 +187,23 @@ void SrEdc::construct(EtherCAT_SlaveHandler *sh, int &start_address, unsigned in
     // Using the serial number as we do in ronex is probably a worse option here.
     device_id_ = "";
   }
-
-  nodehandle_ = ros::NodeHandle(device_id_);
-  nh_tilde_ = ros::NodeHandle(ros::NodeHandle("~"), device_id_);
+  ros::NodeHandle nh_priv = ros::NodeHandle("~");
+  bool use_ns = true;
+  if(!nh_priv.getParam("use_ns", use_ns))
+    ROS_INFO_STREAM("use_ns not set for " << nh_priv.getNamespace());
+  
+  if(use_ns)
+  {
+    nodehandle_ = ros::NodeHandle(device_id_);
+    ROS_INFO_STREAM("Using namespace in sr_edc");
+  }
+  else
+  {
+    ROS_INFO_STREAM("Not using namespace in sr_edc");
+    nodehandle_ = ros::NodeHandle();
+  }
+  nh_tilde_ = ros::NodeHandle(nh_priv, device_id_);
+  
   serviceServer = nodehandle_.advertiseService("SimpleMotorFlasher", &SrEdc::simple_motor_flasher, this);
 
   // get the alias from the parameter server if it exists

--- a/sr_tactile_sensor_controller/CMakeLists.txt
+++ b/sr_tactile_sensor_controller/CMakeLists.txt
@@ -15,6 +15,13 @@ find_package(catkin REQUIRED COMPONENTS
   sr_hardware_interface
 )
 
+# Declare catkin package
+catkin_package(
+CATKIN_DEPENDS controller_interface sr_hardware_interface pluginlib sr_robot_msgs realtime_tools ros_ethercat_model sr_robot_lib
+INCLUDE_DIRS include
+LIBRARIES ${PROJECT_NAME}
+)
+
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/sr_tactile_sensor_controller.cpp
@@ -24,13 +31,6 @@ add_library(${PROJECT_NAME} src/sr_tactile_sensor_controller.cpp
                             src/sr_ubi_tactile_sensor_publisher.cpp)
 add_dependencies(sr_tactile_sensor_controller ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
-# Declare catkin package
-catkin_package(
-CATKIN_DEPENDS controller_interface sr_hardware_interface pluginlib sr_robot_msgs realtime_tools ros_ethercat_model sr_robot_lib
-INCLUDE_DIRS include
-LIBRARIES ${PROJECT_NAME}
-)
 
 install(TARGETS sr_tactile_sensor_controller 
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/sr_tactile_sensor_controller/src/sr_tactile_sensor_controller.cpp
+++ b/sr_tactile_sensor_controller/src/sr_tactile_sensor_controller.cpp
@@ -42,6 +42,8 @@
 #include <sr_tactile_sensor_controller/sr_pst_tactile_sensor_publisher.hpp>
 #include <sr_tactile_sensor_controller/sr_biotac_tactile_sensor_publisher.hpp>
 #include <sr_tactile_sensor_controller/sr_ubi_tactile_sensor_publisher.hpp>
+#include <map>
+#include <string>
 
 using namespace std;
 
@@ -53,18 +55,55 @@ SrTactileSensorController::SrTactileSensorController()
 
 bool SrTactileSensorController::init(ros_ethercat_model::RobotState* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh)
 {
+  std::string serial_id;
+  std::string hand_id;
+  std::string joint_prefix;
+  std::map<std::string, std::string> joint_prefix_mapping;
 
-  if (!controller_nh.getParam("prefix", prefix_))
+  if (!controller_nh.getParam("prefix", joint_prefix))
   {
     ROS_ERROR("Parameter 'prefix' not set");
     return false;
   }
 
-  //this should handle the case where we don't want a prefix
-  if (!prefix_.empty())
+  if (!joint_prefix.empty())
   {
-    nh_prefix_ = ros::NodeHandle(root_nh, prefix_);
-    prefix_+="_";
+    prefix_ = joint_prefix + "_";
+
+    // find the serial that matches the joint_prefix
+    ros::param::get("/hand/joint_prefix", joint_prefix_mapping);
+    for (map<string, string>::const_iterator prefix_iter = joint_prefix_mapping.begin();
+           prefix_iter != joint_prefix_mapping.end(); ++prefix_iter)
+    {
+      if (prefix_ == prefix_iter->second)
+        serial_id = prefix_iter->first;
+    }
+
+    // find the mapping for this serial
+    if (!serial_id.empty())
+    {
+      if (!root_nh.getParam("/hand/mapping/"+serial_id , hand_id))
+      {
+        ROS_INFO_STREAM("Mapping not set for serial_id " << serial_id << ", using prefix as hand_id");
+        hand_id = joint_prefix;
+      }
+    }
+    else
+    {
+      ROS_INFO_STREAM("Cannot find the serial corresponding to prefix " << prefix_);
+      // TODO: normally the sensors handlers should be found via serial_id, and hence fail here
+      // currently they are found via joint_prefix in one of the actuators, so we don't care yet.
+      hand_id = joint_prefix;
+    }
+  }
+
+  if (!hand_id.empty())
+  {
+    nh_prefix_ = ros::NodeHandle(root_nh, hand_id);
+    if (prefix_.empty())
+    {
+      prefix_ = hand_id + "_";
+    }
   }
   else
   {
@@ -84,12 +123,11 @@ bool SrTactileSensorController::init(ros_ethercat_model::RobotState* hw, ros::No
       ROS_ERROR("Parameter 'publish_rate' not set");
       return false;
     }
-
     return true;
   }
   else
   {
-    ROS_ERROR_STREAM("Could not find the "<<prefix_<<"FFJ0 actuator");
+    ROS_ERROR_STREAM("Could not find the " << prefix_ << "FFJ0 actuator");
     return false;
   }
 }


### PR DESCRIPTION
fixes #111 
Tested on two hands, with or without namespaced realtime loop. Tactile topic get always to correct /namespace/tactile  with namespace being the hand_id or the prefix in the yaml if no mapping is given or is the group namespace if mapping is given as empty string.

The other commit on CMake fixing was necessary as I use catkin tools now and it did not like having catkin_package declaring stuff after targets for compilation are generated.
