### PR TITLE
Permit substition args in the robot_description arg of hand launch file

### DIFF
--- a/sr_edc_launch/sr_edc.launch
+++ b/sr_edc_launch/sr_edc.launch
@@ -7,7 +7,7 @@
   <!-- Set to 0 if we don't want to run calibration controllers (e.g. for the muscle hand) -->
   <arg name="calibration_controllers" default="1"/>
   <!-- Xacro file containing the robot description we want to load -->
-  <arg name="robot_description" default="$(find sr_description)/robots/shadowhand_motor.urdf.xacro"/>
+  <arg name="robot_description" default="'$(find sr_description)/robots/shadowhand_motor.urdf.xacro'"/>
   <!-- The control mode PWM (true) or torque (false) -->
   <arg name="pwm_control" default="$(optenv PWM_CONTROL 1)"/>
   <!-- use ns or not -->
@@ -24,7 +24,8 @@
   <param name="/use_sim_time" value="false"/>
 
   <!-- Loads the robot description from the file passed as an argument -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(arg robot_description)' prefix:=$(arg hand_id)_ initial_z:=$(arg initial_z)"/>
+  <param name="robot_description" command="$(find xacro)/xacro.py $(arg robot_description) prefix:=$(arg hand_id)_ initial_z:=$(arg initial_z)"/>
+
 
   <param name="/hand/mapping/$(arg hand_serial)" value="$(arg hand_id)"/>
   <param name="/hand/joint_prefix/$(arg hand_serial)" value="$(arg hand_id)_"/>

--- a/sr_edc_launch/sr_edc_bimanual.launch
+++ b/sr_edc_launch/sr_edc_bimanual.launch
@@ -7,7 +7,7 @@
   <!-- Set to 0 if we don't want to run calibration controllers (e.g. for the muscle hand) -->
   <arg name="calibration_controllers" default="1"/>
   <!-- Xacro file containing the robot description we want to load -->
-  <arg name="robot_description" default="$(find sr_description)/robots/bimanual_shadowhand_motor.urdf.xacro"/>
+  <arg name="robot_description" default="'$(find sr_description)/robots/bimanual_shadowhand_motor.urdf.xacro'"/>
   <!-- The control mode PWM (true) or torque (false) -->
   <arg name="pwm_control" default="$(optenv PWM_CONTROL 0)"/>
 
@@ -32,7 +32,7 @@
   <param name="/use_sim_time" value="false"/>
 
   <!-- Loads the robot description from the file passed as an argument -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(arg robot_description)'"/>
+  <param name="robot_description" command="$(find xacro)/xacro.py $(arg robot_description)" />
 
   <!-- Load parameters for the right hand -->
   <include file="$(find sr_edc_launch)/load_hand_parameters.xml">


### PR DESCRIPTION
This solves issue #131 
The only thing to take care off, is to check if other scripts use sr_edc_launch and pass this robot_description variable. Then it should be quoted before passing to handle spaces. 

for instance here https://github.com/shadow-robot/sr_interface/blob/508b31bf747d4e0d3ec4cedbbbf0ec4ae0d8a751/sr_robot_launch/launch/srhand.launch#L58

and here https://github.com/shadow-robot/sr_interface/blob/c6a89136a46306cb433b22d4dcbbc5a64dead22b/sr_robot_launch/launch/sr_ur_arm_hand.launch#L83
