### PR TITLE
Permit driver namespacing

### DIFF
--- a/sr_edc_ethercat_drivers/src/sr_edc.cpp
+++ b/sr_edc_ethercat_drivers/src/sr_edc.cpp
@@ -187,9 +187,23 @@ void SrEdc::construct(EtherCAT_SlaveHandler *sh, int &start_address, unsigned in
     // Using the serial number as we do in ronex is probably a worse option here.
     device_id_ = "";
   }
-
-  nodehandle_ = ros::NodeHandle(device_id_);
-  nh_tilde_ = ros::NodeHandle(ros::NodeHandle("~"), device_id_);
+  ros::NodeHandle nh_priv = ros::NodeHandle("~");
+  bool use_ns = true;
+  if(!nh_priv.getParam("use_ns", use_ns))
+    ROS_INFO_STREAM("use_ns not set for " << nh_priv.getNamespace());
+  
+  if(use_ns)
+  {
+    nodehandle_ = ros::NodeHandle(device_id_);
+    ROS_INFO_STREAM("Using namespace in sr_edc");
+  }
+  else
+  {
+    ROS_INFO_STREAM("Not using namespace in sr_edc");
+    nodehandle_ = ros::NodeHandle();
+  }
+  nh_tilde_ = ros::NodeHandle(nh_priv, device_id_);
+  
   serviceServer = nodehandle_.advertiseService("SimpleMotorFlasher", &SrEdc::simple_motor_flasher, this);
 
   // get the alias from the parameter server if it exists

--- a/sr_edc_launch/load_hand_parameters.xml
+++ b/sr_edc_launch/load_hand_parameters.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- Set use_ns to true if the hand_id is not empty string. This is necessary as group tag doesn't accept an empty 'ns' attribute   -->
-  <arg name="use_ns" default="false"/>
+  <arg name="use_ns" default="true"/>
   <!-- The id of the hand will be used to namespace the hand parameters
        the id should   -->
   <arg name="hand_id" default="rh"/>

--- a/sr_edc_launch/load_hand_parameters.xml
+++ b/sr_edc_launch/load_hand_parameters.xml
@@ -1,4 +1,6 @@
 <launch>
+  <!-- Set use_ns to true if the hand_id is not empty string. This is necessary as group tag doesn't accept an empty 'ns' attribute   -->
+  <arg name="use_ns" default="false"/>
   <!-- The id of the hand will be used to namespace the hand parameters
        the id should   -->
   <arg name="hand_id" default="rh"/>
@@ -14,7 +16,7 @@
     <arg name="pwm_control" value="$(arg pwm_control)"/>
   </include>
 
-  <group ns="$(arg hand_id)">
+  <group if="$(arg use_ns)" ns="$(arg hand_id)">
     <!-- We set this argument as a parameter in the parameter server (it is relative so it will be pushed to a namespace if we use a ns), to be able to access it from serveral places:
          - the change control mode service inside the realtime loop will use it
          - the calibration and controller tuner plugins in the GUI will need to use it to deal with a namespaced realtime loop-->
@@ -29,7 +31,27 @@
     <rosparam command="load" file="$(find sr_ethercat_hand_config)/rates/muscle_data_polling.yaml"/>
 
     <!-- load parameters for the robot library -->
-    <include file="$(find sr_robot_lib)/launch/sr_hand_lib.launch">
+    <include file="$(find sr_robot_lib)/launch/sr_hand_lib.launch" >
+      <arg name="hand_id" value="$(arg hand_id)"/>
+      <arg name="mapping_path" value="$(arg mapping_path)"/>
+    </include>
+  </group>
+
+  <group unless="$(arg use_ns)">
+    <!-- We set this argument as a parameter in the parameter server (it is relative so it will be pushed to a namespace if we use a ns), to be able to access it from serveral places:
+         - the change control mode service inside the realtime loop will use it
+         - the calibration and controller tuner plugins in the GUI will need to use it to deal with a namespaced realtime loop-->
+    <param name="hand_id" value="$(arg hand_id)"/>
+    <!-- These params are loaded here as they are not controllers in the sense of the controller_manager, and will be accessed by every hand driver inside its namespace -->
+    <rosparam command="load" file="$(find sr_ethercat_hand_config)/controls/motors/$(arg hand_id)/motor_board_effort_controllers.yaml" />
+
+    <!-- polling rates -->
+    <rosparam command="load" file="$(find sr_ethercat_hand_config)/rates/sensor_data_polling.yaml"/>
+    <rosparam command="load" file="$(find sr_ethercat_hand_config)/rates/motor_data_polling.yaml"/>
+    <rosparam command="load" file="$(find sr_ethercat_hand_config)/rates/muscle_data_polling.yaml"/>
+
+    <!-- load parameters for the robot library -->
+    <include file="$(find sr_robot_lib)/launch/sr_hand_lib.launch" >
       <arg name="hand_id" value="$(arg hand_id)"/>
       <arg name="mapping_path" value="$(arg mapping_path)"/>
     </include>

--- a/sr_edc_launch/sr_edc.launch
+++ b/sr_edc_launch/sr_edc.launch
@@ -10,7 +10,9 @@
   <arg name="robot_description" default="$(find sr_description)/robots/shadowhand_motor.urdf.xacro"/>
   <!-- The control mode PWM (true) or torque (false) -->
   <arg name="pwm_control" default="$(optenv PWM_CONTROL 1)"/>
-  <!-- The ethercat serial number for the right hand -->
+  <!-- use ns or not -->
+  <arg name="use_ns" default="false" />
+  <!-- The ethercat serial number for the hand -->
   <arg name="hand_serial" default="1050"/>
   <!-- The id for the right hand. It needs to be the same (but without trailing underscore) as the prefix used in the hand model. -->
   <arg name="hand_id" default="rh"/>
@@ -22,14 +24,17 @@
   <!-- Loads the robot description from the file passed as an argument -->
   <param name="robot_description" command="$(find xacro)/xacro.py '$(arg robot_description)' prefix:=$(arg hand_id)_"/>
 
-
   <param name="/hand/mapping/$(arg hand_serial)" value="$(arg hand_id)"/>
   <param name="/hand/joint_prefix/$(arg hand_serial)" value="$(arg hand_id)_"/>
+   
+  <!-- The prefix used by the robot_state_publisher -->
+  <arg name="tf_prefix" default="" />
 
   <!-- Load parameters for the hand -->
   <include file="$(find sr_edc_launch)/load_hand_parameters.xml">
     <arg name="hand_id" value="$(arg hand_id)"/>
     <arg name="pwm_control" value="$(arg pwm_control)"/>
+    <arg name="use_ns" value="$(arg use_ns)" />
     <arg name="mapping_path" value="$(arg mapping_path)"/>
   </include>
 
@@ -38,7 +43,6 @@
   <!-- publishes joint 0s joint states on separate topic for debug/tuning -->
   <node pkg="sr_utilities" name="joint_0_pub" type="joint_0_publisher.py"/>
 
-
   <!-- ros_ethercat -->
   <group if="$(arg debug)">
     <node name="realtime_loop" machine="local" pkg="ros_ethercat_loop" type="ros_ethercat_loop"
@@ -46,7 +50,7 @@
           launch-prefix="gdb -ex run -args"><!-- launch-prefix="xterm -hold -e strace -f -e trace=!gettimeofday,futex"/> -->
       <param if="$(arg pwm_control)" name="$(arg hand_id)/default_control_mode" value="PWM"/>
       <param unless="$(arg pwm_control)" name="$(arg hand_id)/default_control_mode" value="FORCE"/>
-
+      <param name="use_ns" value="$(arg use_ns)"/>
       <param name="image_path" value="$(find sr_movements)/movements/test.png"/>
     </node>
   </group>
@@ -55,7 +59,7 @@
           args="-i $(arg eth_port) -r robot_description" output="screen" launch-prefix="ethercat_grant">
       <param if="$(arg pwm_control)" name="$(arg hand_id)/default_control_mode" value="PWM"/>
       <param unless="$(arg pwm_control)" name="$(arg hand_id)/default_control_mode" value="FORCE"/>
-
+      <param name="use_ns" value="$(arg use_ns)"/>
       <param name="image_path" value="$(find sr_movements)/movements/test.png"/>
     </node>
   </group>
@@ -75,6 +79,7 @@
   <!-- Robot state publisher: transforming the joints angles to tf.  -->
   <node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="100.0"/>
+    <param name="tf_prefix" type="string" value="$(arg tf_prefix)"/>
   </node>
 
   <!-- adding tactile state publisher using the tf prefix as a namespace -->

--- a/sr_edc_launch/sr_edc.launch
+++ b/sr_edc_launch/sr_edc.launch
@@ -11,7 +11,7 @@
   <!-- The control mode PWM (true) or torque (false) -->
   <arg name="pwm_control" default="$(optenv PWM_CONTROL 1)"/>
   <!-- use ns or not -->
-  <arg name="use_ns" default="false" />
+  <arg name="use_ns" default="true" />
   <!-- The ethercat serial number for the hand -->
   <arg name="hand_serial" default="1050"/>
   <!-- The id for the right hand. It needs to be the same (but without trailing underscore) as the prefix used in the hand model. -->

--- a/sr_edc_launch/sr_edc_bimanual.launch
+++ b/sr_edc_launch/sr_edc_bimanual.launch
@@ -37,6 +37,7 @@
   <!-- Load parameters for the right hand -->
   <include file="$(find sr_edc_launch)/load_hand_parameters.xml">
     <arg name="hand_id" value="$(arg rh_id)"/>
+    <arg name="use_ns" value="true"/>
     <arg name="pwm_control" value="$(arg pwm_control)"/>
     <arg name="mapping_path" value="$(arg rh_mapping_path)"/>
   </include>
@@ -44,7 +45,8 @@
   <!-- Load parameters for the left hand -->
   <include file="$(find sr_edc_launch)/load_hand_parameters.xml">
     <arg name="hand_id" value="$(arg lh_id)"/>
-    <arg name="pwm_control" value="$(arg pwm_control)"/>
+    <arg name="use_ns" value="true"/>
+    <arg name="pwm_control" value="$(arg pwm_control)" />
     <arg name="mapping_path" value="$(arg lh_mapping_path)"/>
   </include>
 
@@ -80,7 +82,6 @@
     </node>
   </group>
 
-
   <group if="$(arg calibration_controllers)">
     <node name="calibrate_sr_edc" pkg="sr_utilities" type="calibrate_hand_finder.py" output="screen"/>
   </group>
@@ -96,7 +97,6 @@
   <node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="100.0"/>
   </node>
-
     <!-- adding tactile state publisher using the tf prefix as a namespace -->
   <include file="$(find sr_tactile_sensor_controller)/sr_tactile_sensor.launch">
    <arg name="hand_id" value="$(arg rh_id)" />

--- a/sr_tactile_sensor_controller/src/sr_tactile_sensor_controller.cpp
+++ b/sr_tactile_sensor_controller/src/sr_tactile_sensor_controller.cpp
@@ -59,6 +59,9 @@ bool SrTactileSensorController::init(ros_ethercat_model::RobotStateInterface* hw
   std::string robot_state_name;
   controller_nh.param<std::string>("robot_state_name", robot_state_name, "unique_robot_hw");
 
+  bool use_ns = true;
+  ros::NodeHandle nh_priv("~");
+  
   try
   {
     robot_state = hw->getHandle(robot_state_name).getState();
@@ -69,6 +72,11 @@ bool SrTactileSensorController::init(ros_ethercat_model::RobotStateInterface* hw
     return false;
   }
 
+  if (!nh_priv.getParam("use_ns", use_ns))
+  {
+    ROS_INFO("Private parameter 'use_ns' not set, default is using namespace");  
+  }
+  
   if (!controller_nh.getParam("prefix", prefix_))
   {
     ROS_ERROR("Parameter 'prefix' not set");
@@ -78,7 +86,11 @@ bool SrTactileSensorController::init(ros_ethercat_model::RobotStateInterface* hw
   //this should handle the case where we don't want a prefix
   if (!prefix_.empty())
   {
-    nh_prefix_ = ros::NodeHandle(root_nh, prefix_);
+    if(use_ns)
+      nh_prefix_ = ros::NodeHandle(root_nh, prefix_);
+    else
+      nh_prefix_ = ros::NodeHandle(root_nh);
+        
     prefix_+="_";
   }
   else


### PR DESCRIPTION
This solves one point of #56 which is that the sr_edc driver always uses the hand_mapping, whether it is running in a namespace or not (https://github.com/shadow-robot/sr-ros-interface-ethercat/blob/indigo-devel/sr_edc_ethercat_drivers/src/sr_edc.cpp#L191)

The consequences are 
- double namespacing
- missing configuration files that are correctly loaded on the namespace /rh/myparam and not on /rh/rh/myparam as awaited by the driver then.

It also solves part of #111 as suggested in this comment the https://github.com/shadow-robot/sr-ros-interface-ethercat/issues/111#issuecomment-151239902

A simple _use_ns_ private parameter is added to activate or deactivate that behaviour at user convenience.

We have been using this patch for more than 8 months now without any issues and it was tested as part of previous PR #112 

For better understanding and more chance of merging, I rebased and split the use_ns part from the tactile prefix handling (prefix handling in another (future) PR)
