### PR TITLE
Removed dependencies to metapackages

### DIFF
--- a/sr_edc_controller_configuration/package.xml
+++ b/sr_edc_controller_configuration/package.xml
@@ -23,8 +23,10 @@
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>controller_manager</run_depend>
-  <run_depend>ros_controllers</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
   <run_depend>sr_ethercat_hand_config</run_depend>
   <run_depend>pr2_mechanism_msgs</run_depend>
-
+  <run_depend>diagnostic_msgs</run_depend>
+  <run_depend>ros_ethercat_model</run_depend>
+  
 </package>

--- a/sr_edc_launch/package.xml
+++ b/sr_edc_launch/package.xml
@@ -29,8 +29,10 @@
   <run_depend>self_test</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>
-  <run_depend>ros_ethercat</run_depend>
   <run_depend>sr_mechanism_controllers</run_depend>
+  <run_depend>ros_ethercat_model</run_depend>
+  <run_depend>ros_ethercat_loop</run_depend>
+  <run_depend>ros_ethercat_hardware</run_depend>
   <run_depend>sr_description</run_depend>
 
 


### PR DESCRIPTION
This fixes #136 
It was tested on a real hand and had no issues compiling and finding the runtime dependencies.

Dependency to `ros_controllers` was removed and no sub-package had to be added (like effort_controllers) as `sr_edc_controllers_configuration` do not directly depend on it, only on `sr_ethercat_hand_config`. 
And even `sr_ethercat_hand_config` does not depend on `ros_controllers`, only on `sr_mechanism_controllers`.  
`sr_edc_launch` starts a `joint_state_controller` but the latter is listed already in the `ros_ethercat_model`.
I also did not see any pluginlib dependency to the controllers. Maybe in your higher level packages (`sr_robot_launch` ?) that starts `effort_controllers` on the arms ?

Did I miss something or is it an old left over dependency ? If there is a dependency needed, we need to add the packages now to fix catkin tools issues.
