### PR TITLE
Added a parameter reading for the pos_filter

### DIFF
--- a/sr_robot_lib/src/sr_motor_hand_lib.cpp
+++ b/sr_robot_lib/src/sr_motor_hand_lib.cpp
@@ -131,6 +131,15 @@ namespace shadow_robot
     {
       // add the joint and the vector of joints.
       Joint joint;
+      float tau;
+
+      // read the parameters tau from the parameter server
+      ostringstream full_param;
+      string act_name = boost::to_lower_copy(joint_names[index]);
+      full_param << act_name << "/pos_filter/tau";
+      this->nodehandle_.template param<float>(full_param.str(), tau, 0.05);
+      full_param.str("");
+      joint.pos_filter = sr_math_utils::filters::LowPassFilter(tau);
 
       // update the joint variables
       joint.joint_name = joint_names[index];


### PR DESCRIPTION
related to #138 
permits to pass different tau for the pos filter. Is backward compatible with same default tau as before if none is provided.

Is read from the motor parameters for simplicity and is not so badly placed as the filter is for the "actuator" readings which is the low-level firmware on the motor-boards. 
