### PR TITLE
B#141 actuator check

### DIFF
--- a/sr_robot_lib/src/sr_motor_hand_lib.cpp
+++ b/sr_robot_lib/src/sr_motor_hand_lib.cpp
@@ -144,6 +144,14 @@ namespace shadow_robot
         motor_wrapper->motor_id = actuator_ids[index];
         motor_wrapper->actuator = static_cast<SrMotorActuator *> (this->hw_->getActuator(
                 this->joint_prefix_ + joint.joint_name));
+        if (motor_wrapper->actuator == NULL)
+        {
+          ROS_WARN_STREAM("No actuator found for joint " <<
+                          this->joint_prefix_ + joint.joint_name <<
+                          " (check the robot_description contains it)");
+          joint.has_actuator = false;
+          continue;
+        }
 
         ostringstream ss;
         ss << "change_force_PID_" << joint_names[index];


### PR DESCRIPTION
Solves #141
- Checks if actuator is found in the hardware, otherwise deactivate the actuator in this joint. 
- Warns the user to check the robot_description. 

`[ WARN] [1466451053.082910015]: No actuator found for joint lh_WRJ2 (check the robot_description contains it)`
- Does not crash
- Could permits to continue loading the hand if a joint is not found in the URDF. However will fail with explicit errors on controller spawner 

```
[INFO] [WallTime: 1466451054.536980] Controller Spawner: Loaded controllers: joint_state_controller
[ERROR] [1466451054.573501169]: Could not find the lh_FFJ0 actuator
[ERROR] [1466451054.573551505]: Failed to initialize the controller
```
