### PR TITLE
Specific boost includes

### DIFF
--- a/sr_robot_lib/include/sr_robot_lib/generic_updater.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/generic_updater.hpp
@@ -33,7 +33,7 @@
 #include <vector>
 #include <list>
 #include <queue>
-#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
 #include <boost/smart_ptr.hpp>
 #include <sr_external_dependencies/types_for_external.h>
 

--- a/sr_robot_lib/include/sr_robot_lib/motor_updater.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/motor_updater.hpp
@@ -33,7 +33,6 @@
 #include <vector>
 #include <list>
 #include <queue>
-#include <boost/thread.hpp>
 #include <boost/smart_ptr.hpp>
 #include "sr_robot_lib/generic_updater.hpp"
 

--- a/sr_robot_lib/include/sr_robot_lib/muscle_updater.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/muscle_updater.hpp
@@ -33,8 +33,6 @@
 #include <vector>
 #include <list>
 #include <queue>
-#include <boost/thread.hpp>
-#include <boost/smart_ptr.hpp>
 #include "sr_robot_lib/generic_updater.hpp"
 
 #include <sr_external_dependencies/types_for_external.h>

--- a/sr_robot_lib/include/sr_robot_lib/sensor_updater.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/sensor_updater.hpp
@@ -32,8 +32,6 @@
 #include <vector>
 #include <list>
 #include <queue>
-#include <boost/thread.hpp>
-#include <boost/smart_ptr.hpp>
 #include "sr_robot_lib/generic_updater.hpp"
 
 #include <sr_external_dependencies/types_for_external.h>

--- a/sr_robot_lib/include/sr_robot_lib/sr_robot_lib.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/sr_robot_lib.hpp
@@ -29,7 +29,8 @@
 
 #include <boost/smart_ptr.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
-#include <boost/thread.hpp>
+#include <boost/thread/thread.hpp>
+#include <boost/thread/mutex.hpp>
 #include <vector>
 #include <utility>
 #include <string>

--- a/sr_robot_lib/src/sensor_updater.cpp
+++ b/sr_robot_lib/src/sensor_updater.cpp
@@ -27,6 +27,8 @@
 
 #include "sr_robot_lib/sensor_updater.hpp"
 #include <boost/foreach.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/smart_ptr.hpp>
 #include <iostream>
 #include <vector>
 


### PR DESCRIPTION
A bug in boost 1.58 in future.hpp prevents from building on xenial.
This PR just provides specific includes instead of the generic one for thread.hpp, and does not change functionality
It also removes unnecessary includes (they are included in the parent and are not locally used in the child so do not need to be included again)

Since the change does not affect indigo-devel, I suggest to merge it there.
Main loop and driver changes were tested on our system on indigo.
