### PR TITLE
Remove dependency to unused sr_self_test

### DIFF
--- a/sr_robot_lib/CMakeLists.txt
+++ b/sr_robot_lib/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(catkin REQUIRED COMPONENTS
         diagnostic_updater
         realtime_tools
         controller_manager_msgs
-        sr_self_test
         roscpp
         rostest
 )
@@ -47,7 +46,6 @@ catkin_package(
         diagnostic_updater
         realtime_tools
         controller_manager_msgs
-        sr_self_test
         roscpp
         rospy
         INCLUDE_DIRS include

--- a/sr_robot_lib/include/sr_robot_lib/sr_robot_lib.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/sr_robot_lib.hpp
@@ -53,7 +53,7 @@
 #include <sr_utilities/calibration.hpp>
 #include <sr_utilities/thread_safe_map.hpp>
 
-#include <sr_self_test/sr_self_test.hpp>
+// #include <sr_self_test/sr_self_test.hpp>
 
 #include "sr_robot_lib/sr_joint_motor.hpp"
 #include "sr_robot_lib/generic_tactiles.hpp"

--- a/sr_robot_lib/package.xml
+++ b/sr_robot_lib/package.xml
@@ -32,7 +32,6 @@
   <build_depend>diagnostic_updater</build_depend>
   <build_depend>realtime_tools</build_depend>
   <build_depend>controller_manager_msgs</build_depend>
-  <build_depend>sr_self_test</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rostest</build_depend>
 
@@ -47,7 +46,6 @@
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>realtime_tools</run_depend>
   <run_depend>controller_manager_msgs</run_depend>
-  <run_depend>sr_self_test</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
 


### PR DESCRIPTION
sr_self_test is already commented out everywhere except the include. 
commenting this include permits to remove the dependency (and remove sr_self_test later on if needed)