### PR TITLE
Switched to tinyxml2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ jobs:
   build:
     working_directory: /tmp/repository
     docker:
-      - image: shadowrobot/build-tools:xenial-kinetic
+      - image: shadowrobot/build-tools:bionic-melodic
         environment:
           toolset_branch: master
           server_type: circle
-          ros_release_name: kinetic
-          ubuntu_version_name: xenial
+          ros_release_name: melodic
+          ubuntu_version_name: bionic
           used_modules: check_cache,code_style_check
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
   global:
     - toolset_branch: master
     - server_type: travis
-    - ros_release_name: kinetic
-    - ubuntu_version_name: xenial
+    - ros_release_name: melodic
+    - ubuntu_version_name: bionic
     - used_modules: check_cache,code_coverage
     - remote_shell_script: 'https://raw.githubusercontent.com/shadow-robot/sr-build-tools/$toolset_branch/bin/sr-run-ci-build.sh'
 

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -14,6 +14,14 @@ settings:
 
 trunks:
   - name: kinetic-devel
+  - name: melodic-devel
+    settings:
+      ubuntu:
+        version: bionic
+      ros:
+        release: melodic
+      docker:
+        tag: bionic-melodic
 
 branch:
-  parent: kinetic-devel
+  parent: melodic-devel

--- a/repository.rosinstall
+++ b/repository.rosinstall
@@ -5,7 +5,7 @@
 
 - git:
     uri: https://github.com/shadow-robot/sr_core.git
-    version: 'kinetic-devel'
+    version: 'melodic-devel'
     local-name: sr_core
 
 - git:

--- a/sr_robot_lib/CMakeLists.txt
+++ b/sr_robot_lib/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
         sr_external_dependencies
         sr_robot_msgs
         std_srvs
+        cmake_modules
         diagnostic_updater
         realtime_tools
         controller_manager_msgs
@@ -17,6 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
         rostest
 )
 find_package(Boost REQUIRED COMPONENTS thread)
+find_package(TinyXML2 REQUIRED)
 
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
@@ -48,6 +50,7 @@ catkin_package(
         rospy
         INCLUDE_DIRS include
         LIBRARIES sr_hand_lib
+        DEPENDS tinyxml2
 )
 
 add_library(sr_hand_lib
@@ -82,8 +85,9 @@ IF (DEFINED jenkins)
 ENDIF (DEFINED jenkins)
 
 if (COMMAND add_rostest_gtest)
+    include_directories(${TinyXML2_INCLUDE_DIRS})
     add_rostest_gtest(test_robot_lib test/sr_hand_lib.test test/test_robot_lib.cpp)
-    target_link_libraries(test_robot_lib sr_hand_lib gcov ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+    target_link_libraries(test_robot_lib sr_hand_lib gcov ${catkin_LIBRARIES} ${TinyXML2_LIBRARIES} ${GTEST_LIBRARIES})
 
     add_rostest_gtest(motor_updater_test test/motor_updater.test test/motor_updater_test.cpp)
     target_link_libraries(motor_updater_test sr_hand_lib gcov ${catkin_LIBRARIES} ${GTEST_LIBRARIES})

--- a/sr_robot_lib/package.xml
+++ b/sr_robot_lib/package.xml
@@ -29,11 +29,13 @@
   <build_depend>sr_external_dependencies</build_depend>
   <build_depend>sr_robot_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>diagnostic_updater</build_depend>
   <build_depend>realtime_tools</build_depend>
   <build_depend>controller_manager_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rostest</build_depend>
+  <build_depend>tinyxml2</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>sr_utilities</run_depend>

--- a/sr_robot_lib/test/test_robot_lib.cpp
+++ b/sr_robot_lib/test/test_robot_lib.cpp
@@ -61,9 +61,9 @@ public:
 
   HandLibTest()
   {
-    TiXmlElement *root;
-    TiXmlElement *root_element;
-    TiXmlDocument xml;
+    tinyxml2::XMLElement *root;
+    tinyxml2::XMLElement *root_element;
+    tinyxml2::XMLDocument xml;
     std::string robot_description;
     if (ros::param::get("/robot_description", robot_description))
     {

--- a/sr_robot_lib/test/test_robot_lib.cpp
+++ b/sr_robot_lib/test/test_robot_lib.cpp
@@ -26,6 +26,7 @@
 
 #include "sr_robot_lib/sr_motor_hand_lib.hpp"
 #include <sr_mechanism_model/simple_transmission.hpp>
+#include <tinyxml2.h>
 #include <gtest/gtest.h>
 #include <ros/ros.h>
 #include <utility>


### PR DESCRIPTION
switched to tinyxml2 (removed deprecated warning in bionic), not backward compatible, so please create a branch melodic-devel. 
Other similar PR should be merged at the same time to fully upgrade to tinyxml2