### PR TITLE
edc_ethercat_drivers: account for new API in binutils 2.34

### DIFF
--- a/sr_edc_ethercat_drivers/src/sr_edc.cpp
+++ b/sr_edc_ethercat_drivers/src/sr_edc.cpp
@@ -845,18 +845,34 @@ void SrEdc::find_address_range(bfd *fd, unsigned int *smallest_start_address, un
   for (s = fd->sections; s; s = s->next)
   {
     // Only the sections with the LOAD flag on will be considered
+#ifdef bfd_get_section_flags
     if (bfd_get_section_flags(fd, s) & (SEC_LOAD))
+#else
+    if (bfd_section_flags(s) & (SEC_LOAD))
+#endif
     {
       // Only the sections with the same VMA (virtual memory address) and LMA (load MA) will be considered
       // http://www.delorie.com/gnu/docs/binutils/ld_7.html
+#ifdef bfd_section_lma
       if (bfd_section_lma(fd, s) == bfd_section_vma(fd, s))
+#else
+      if (bfd_section_lma(s) == bfd_section_vma(s))
+#endif
       {
+#ifdef bfd_section_lma
         section_addr = (unsigned int) bfd_section_lma(fd, s);
+#else
+        section_addr = (unsigned int) bfd_section_lma(s);
+#endif
         if (section_addr >= 0x7fff)
         {
           continue;
         }
+#ifdef bfd_section_size
         section_size = (unsigned int) bfd_section_size(fd, s);
+#else
+        section_size = (unsigned int) bfd_section_size(s);
+#endif
         *smallest_start_address = std::min(section_addr, *smallest_start_address);
         *biggest_end_address = std::max(*biggest_end_address, section_addr + section_size);
       }
@@ -873,13 +889,25 @@ bool SrEdc::read_content_from_object_file(bfd *fd, bfd_byte *content, unsigned i
   for (s = fd->sections; s; s = s->next)
   {
     // Only the sections with the LOAD flag on will be considered
+#ifdef bfd_get_section_flags
     if (bfd_get_section_flags(fd, s) & (SEC_LOAD))
+#else
+    if (bfd_section_flags(s) & (SEC_LOAD))
+#endif
     {
       // Only the sections with the same VMA (virtual memory address) and LMA (load MA) will be considered
       // http://www.delorie.com/gnu/docs/binutils/ld_7.html
+#ifdef bfd_section_lma
       if (bfd_section_lma(fd, s) == bfd_section_vma(fd, s))
+#else
+      if (bfd_section_lma(s) == bfd_section_vma(s))
+#endif
       {
+#ifdef bfd_section_lma
         section_addr = (unsigned int) bfd_section_lma(fd, s);
+#else
+        section_addr = (unsigned int) bfd_section_lma(s);
+#endif
         // The sections starting at an address higher than 0x7fff will be ignored as they are
         // not proper "code memory" firmware
         // (they can contain the CONFIG bits of the microcontroller, which we don't want to write here)
@@ -887,7 +915,11 @@ bool SrEdc::read_content_from_object_file(bfd *fd, bfd_byte *content, unsigned i
         {
           continue;
         }
+#ifdef bfd_section_size
         section_size = (unsigned int) bfd_section_size(fd, s);
+#else
+        section_size = (unsigned int) bfd_section_size(s);
+#endif
         bfd_get_section_contents(fd, s, content + (section_addr - base_addr), 0, section_size);
       }
       else


### PR DESCRIPTION
This patch does not change anything.
It just adds #ifdef's to support the simplified API as required.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Put an x in the boxes that apply. You can also fill these out after creating the PR. This is a reminder of what we should look for before merging this code. I have:

- [x] Read and follow the [contributing guidelines](https://github.com/shadow-robot/sr_documentation/blob/master/CONTRIBUTING.md).
- [ ] Tested on real hardware (if appropriate)