### PR TITLE
SRC-4962 Switch controllers in change_control_type_callback

### DIFF
--- a/sr_robot_lib/include/sr_robot_lib/sr_motor_robot_lib.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/sr_motor_robot_lib.hpp
@@ -41,6 +41,7 @@
 #include <queue>
 #include <utility>
 #include <list>
+#include <set>
 #include <vector>
 
 namespace shadow_robot
@@ -214,9 +215,6 @@ protected:
   // The current type of control (FORCE demand or PWM demand sent to the motors)
   sr_robot_msgs::ControlType control_type_;
 
-  // Names of joints to use for switching controllers when control type changes
-  std::vector<std::string> joint_names_;
-
   // A service server used to change the control type on the fly.
   ros::ServiceServer change_control_type_;
 
@@ -231,6 +229,8 @@ protected:
    */
   bool change_control_type_callback_(sr_robot_msgs::ChangeControlType::Request &request,
                                      sr_robot_msgs::ChangeControlType::Response &response);
+
+  std::set<std::string> get_running_controllers();
 
   /*
    * Switch controllers for joint specified by joint_names_ between PWM and

--- a/sr_robot_lib/include/sr_robot_lib/sr_motor_robot_lib.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/sr_motor_robot_lib.hpp
@@ -239,7 +239,7 @@ protected:
    * this->nullify_demand_ will be set to true and it will be restored to
    * original value after switch.
    */
-  void switch_controllers();
+  void switch_controllers(sr_robot_msgs::ControlType control_type);
 
   // The Flag which will be sent to change the motor controls
   std::queue<std::vector<sr_robot_msgs::MotorSystemControls>,

--- a/sr_robot_lib/include/sr_robot_lib/sr_motor_robot_lib.hpp
+++ b/sr_robot_lib/include/sr_robot_lib/sr_motor_robot_lib.hpp
@@ -213,20 +213,12 @@ protected:
 
   // The current type of control (FORCE demand or PWM demand sent to the motors)
   sr_robot_msgs::ControlType control_type_;
-  /*
-   * Flag to signal that there has been a change in the value of control_type_ and certain actions are required.
-   * The flag is set in the callback function of the change_control_type_ service.
-   * The flag is checked in build_command() and the necessary actions are taken there.
-   * These actions involve calling services in the controller manager and all the active controllers. This is the
-   * reason why we don't do it directly in the callback function. As we use a single thread to serve the callbacks,
-   * doing so would cause a deadlock, thus we do it in the realtime loop thread instead.
-   */
-  bool control_type_changed_flag_;
+
+  // Names of joints to use for switching controllers when control type changes
+  std::vector<std::string> joint_names_;
+
   // A service server used to change the control type on the fly.
   ros::ServiceServer change_control_type_;
-  // A mutual exclusion object to ensure that no command will be sent to the robot while a change
-  // in the control type (PWM or torque) is ongoing
-  boost::shared_ptr<boost::mutex> lock_command_sending_;
 
   /*
    * The callback to the change_control_type_ service. Updates
@@ -241,15 +233,13 @@ protected:
                                      sr_robot_msgs::ChangeControlType::Response &response);
 
   /*
-   * Load the necessary parameters in the Parameter Server and
-   * calls a service for every controller currently loaded in the controller manager to make it
-   * reload (resetGains()) its parameters from the Parameter Server
-   *
-   * @param control_type The new active control type (PWM or torque)
-   *
-   * @return true if all the steps successful
+   * Switch controllers for joint specified by joint_names_ between PWM and
+   * torque modes. This method will create a new thread so controllers are not
+   * guaranteed to be already switched once this method returns. During switch
+   * this->nullify_demand_ will be set to true and it will be restored to
+   * original value after switch.
    */
-  bool change_control_parameters(int16_t control_type);
+  void switch_controllers();
 
   // The Flag which will be sent to change the motor controls
   std::queue<std::vector<sr_robot_msgs::MotorSystemControls>,

--- a/sr_robot_lib/src/sr_motor_robot_lib.cpp
+++ b/sr_robot_lib/src/sr_motor_robot_lib.cpp
@@ -26,7 +26,7 @@
 
 #include "sr_robot_lib/sr_motor_robot_lib.hpp"
 #include <string>
-#include <thread>
+#include <thread>  // NOLINT(build/c++11)
 #include <vector>
 #include <utility>
 #include <boost/foreach.hpp>
@@ -1255,8 +1255,7 @@ namespace shadow_robot
 
       // Restore nullify_demand to the original state
       this->nullify_demand_ = nullify_demand;
-    }
-    );
+    });  // NOLINT(whitespace/braces)
     client_thread.detach();
   }
 

--- a/sr_robot_lib/src/sr_motor_robot_lib.cpp
+++ b/sr_robot_lib/src/sr_motor_robot_lib.cpp
@@ -1194,16 +1194,23 @@ namespace shadow_robot
 
     if (control_type_.control_type != request.control_type.control_type)
     {
-      control_type_ = request.control_type;
-      switch_controllers();
+      switch_controllers(request.control_type);
     }
     response.result = control_type_;
     return true;
   }
 
   template<class StatusType, class CommandType>
-  void SrMotorRobotLib<StatusType, CommandType>::switch_controllers()
+  void SrMotorRobotLib<StatusType, CommandType>::switch_controllers(sr_robot_msgs::ControlType control_type)
   {
+    // Save the current state of nullify_demand
+    bool nullify_demand = this->nullify_demand_;
+
+    // Send zeros to motors while controllers are being switched
+    this->nullify_demand_ = true;
+
+    control_type_ = control_type;
+
     std::string controller_from_suffix, controller_to_suffix;
     if (control_type_.control_type == sr_robot_msgs::ControlType::PWM)
     {
@@ -1219,12 +1226,6 @@ namespace shadow_robot
     }
     std::thread client_thread([=]()
     {
-      // Save the current state of nullify_demand
-      bool nullify_demand = this->nullify_demand_;
-
-      // Send zeros to motors while controllers are being switched
-      this->nullify_demand_ = true;
-
       ros::NodeHandle nh;
 
       std::set<std::string> loaded_controllers;

--- a/sr_robot_lib/src/sr_motor_robot_lib.cpp
+++ b/sr_robot_lib/src/sr_motor_robot_lib.cpp
@@ -1224,7 +1224,7 @@ namespace shadow_robot
       controller_from_suffix = "_position_controller";
       controller_to_suffix = "_effort_controller";
     }
-    std::thread client_thread([=]()
+    std::thread switch_controllers_thread([=]()
     {
       ros::NodeHandle nh;
 
@@ -1297,7 +1297,7 @@ namespace shadow_robot
       // Restore nullify_demand to the original state
       this->nullify_demand_ = nullify_demand;
     });  // NOLINT(whitespace/braces)
-    client_thread.detach();
+    switch_controllers_thread.detach();
   }
 
   template<class StatusType, class CommandType>

--- a/sr_robot_lib/src/sr_motor_robot_lib.cpp
+++ b/sr_robot_lib/src/sr_motor_robot_lib.cpp
@@ -82,7 +82,8 @@ namespace shadow_robot
               "lfj0", "lfj3", "lfj4", "lfj5",
               "thj1", "thj2", "thj3", "thj4", "thj5",
               "wrj1", "wrj2"
-            })
+            }
+            )
   {
     // reading the parameters to check for a specified default control type
     // using FORCE control if no parameters are set
@@ -1223,8 +1224,8 @@ namespace shadow_robot
       this->nullify_demand_ = true;
 
       ros::NodeHandle nh;
-      ros::ServiceClient switch_controller_client = nh.template serviceClient<controller_manager_msgs::SwitchController>(
-        "controller_manager/switch_controller");
+      ros::ServiceClient switch_controller_client = nh.template serviceClient
+        <controller_manager_msgs::SwitchController>("controller_manager/switch_controller");
       for (std::string joint_name : joint_names_)
       {
         controller_manager_msgs::SwitchController switch_controller;
@@ -1254,7 +1255,8 @@ namespace shadow_robot
 
       // Restore nullify_demand to the original state
       this->nullify_demand_ = nullify_demand;
-    });
+    }
+    );
     client_thread.detach();
   }
 

--- a/sr_robot_lib/src/sr_motor_robot_lib.cpp
+++ b/sr_robot_lib/src/sr_motor_robot_lib.cpp
@@ -26,6 +26,7 @@
 
 #include "sr_robot_lib/sr_motor_robot_lib.hpp"
 #include <string>
+#include <set>
 #include <thread>  // NOLINT(build/c++11)
 #include <vector>
 #include <utility>
@@ -1250,7 +1251,8 @@ namespace shadow_robot
       {
         std::string joint_name = joint.joint_name;
         boost::algorithm::to_lower(joint_name);
-        if (boost::algorithm::ends_with(joint_name, "j1") | boost::algorithm::ends_with(joint_name, "j2")) {
+        if (boost::algorithm::ends_with(joint_name, "j1") | boost::algorithm::ends_with(joint_name, "j2"))
+        {
           // Ignore underactuated joints as they don't have associated controller
           continue;
         }


### PR DESCRIPTION
## Proposed changes

Modify change_control_type_callback in the following way:
- Callback will no longer block real time control loop by sharing mutex with it
- Callback will no longer block real time control loop by requesting to switch controllers
- Callback will span a background thread to switch controllers (can't call other services from inside callback)
- Before controllers are switched "nullify demand" mode will be activated which will send 0 to the motors during switching
- Controllers will be switched one by one instead of all together to minimise strain on computer resources
- If controller being started is not in loaded controller list it will be loaded
- If all controllers are switched successfully "nullify demand" mode will be reset to the previous value
- if any of controllers failed to switch, then hand will stay in "nullify demand" mode

Python code calling this service is changed not to do controller switching in a separate PR as it is in a different repository (see https://github.com/shadow-robot/sr_interface/pull/647).

2 lint errors were ignored:
- `#include <thread>` causes: <thread> is an unapproved C++11 header.  [build/c++11]
- Creating a thread with multi-line expression causes one of these 2:
  - } should be on a line by itself  [whitespace/braces]
  - Closing ) should be moved to the previous line  [whitespace/parens] 

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
