### PR TITLE
Do Not Specify Default Serial

### DIFF
--- a/sr_robot_lib/launch/sr_hand_lib.launch
+++ b/sr_robot_lib/launch/sr_hand_lib.launch
@@ -6,7 +6,7 @@
        If it's not "" then it's usually "rh"  -->
   <arg name="hand_id" default="rh"/>
   <!-- The ethercat serial number for the hand -->
-  <arg name="hand_serial" default="111"/>
+  <arg name="hand_serial" />
   <!-- the path to the mapping files -->
   <arg name="mapping_path" default="$(find sr_edc_launch)/mappings/default_mappings/rh_E_v3.yaml"/>
 


### PR DESCRIPTION
We wrapped this launch file into our own launch structure and
initially failed to add the new hand_serial parameter during migration to noetic.
So although we specified the correct serial in other places it loaded
the wrong calibration without complains and the hand misbehaves.

Crucial configuration parameters must really not have defaults.