### PR TITLE
fix imu data

### DIFF
--- a/sr_edc_ethercat_drivers/src/sr09.cpp
+++ b/sr_edc_ethercat_drivers/src/sr09.cpp
@@ -477,15 +477,15 @@ bool SR09::unpackState(unsigned char *this_buffer, unsigned char *prev_buffer)
 
     extra_analog_msg.layout.dim[0].label = "accelerometer";
     extra_analog_msg.layout.dim[0].size = 3;
-    extra_analog_msg.data[0] = status_data->sensors[ACCX];
-    extra_analog_msg.data[1] = status_data->sensors[ACCY];
-    extra_analog_msg.data[2] = status_data->sensors[ACCZ];
+    extra_analog_msg.data[0] = (int16_t)status_data->sensors[ACCX];
+    extra_analog_msg.data[1] = (int16_t)status_data->sensors[ACCY];
+    extra_analog_msg.data[2] = (int16_t)status_data->sensors[ACCZ];
 
     extra_analog_msg.layout.dim[1].label = "gyrometer";
     extra_analog_msg.layout.dim[1].size = 3;
-    extra_analog_msg.data[3] = status_data->sensors[GYRX];
-    extra_analog_msg.data[4] = status_data->sensors[GYRY];
-    extra_analog_msg.data[5] = status_data->sensors[GYRZ];
+    extra_analog_msg.data[3] = (int16_t)status_data->sensors[GYRX];
+    extra_analog_msg.data[4] = (int16_t)status_data->sensors[GYRY];
+    extra_analog_msg.data[5] = (int16_t)status_data->sensors[GYRZ];
 
     extra_analog_msg.layout.dim[2].label = "analog_inputs";
     extra_analog_msg.layout.dim[2].size = 4;

--- a/sr_edc_ethercat_drivers/src/sr09.cpp
+++ b/sr_edc_ethercat_drivers/src/sr09.cpp
@@ -4,7 +4,7 @@
 *         Ugo Cupcic <ugo@shadowrobot.com>, Toni Oliver <toni@shadowrobot.com>,
 *         Dan Greenwald <dg@shadowrobot.com>, contact <software@shadowrobot.com>
 *
-/* Copyright 2017 Shadow Robot Company Ltd.
+/* Copyright 2017, 2024 Shadow Robot Company Ltd.
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free


### PR DESCRIPTION
## Proposed changes

Jira Bug: [SRC-7379](https://shadowrobot.atlassian.net/browse/SRC-7379)

The IMU data being retrieved from the Palm and published into /rh/palm_extras (or /lh/palm_extras) (which can also be observed in plot format using the RQT plugin “Hand Data Visualiser - Palm Extras“) are now cast into signed integers `int16_t`, such data clockwise, and anti-clockwise physical rotations of the hand along its axis result. respectively, in positive and negative acceleration and gyro-meter values of the associated signals.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).


[SRC-7379]: https://shadowrobot.atlassian.net/browse/SRC-7379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ